### PR TITLE
story/SC-5195 (PMVS Editor Workflow Changes)

### DIFF
--- a/src/Kanoop/stringutil.cpp
+++ b/src/Kanoop/stringutil.cpp
@@ -309,7 +309,7 @@ StringUtil::Levenshtein::Levenshtein(const QString &s1, const QString &s2)
     unsigned int x, y, s1len, s2len;
     s1len = s1.length();
     s2len = s2.length();
-    unsigned int matrix[s2len+1][s1len+1];
+    QList<QList<unsigned int>> matrix(s2len + 1, QList<unsigned int>(s1len + 1, 0));
     matrix[0][0] = 0;
     for (x = 1; x <= s2len; x++) {
         matrix[x][0] = matrix[x-1][0] + 1;

--- a/src/Kanoop/userutil.cpp
+++ b/src/Kanoop/userutil.cpp
@@ -1,5 +1,7 @@
 #include "Kanoop/userutil.h"
 
+#include <QList>
+
 #ifndef __WIN32
 #include "unistd.h"
 #else
@@ -71,9 +73,9 @@ bool UserUtil::isUserMemberOfGroup(uid_t uid, gid_t gid)
     int ngroups = 0;
     getgrouplist(pw->pw_name, pw->pw_gid, nullptr, &ngroups);
 
-    gid_t groups[ngroups];
+    QList<gid_t> groups(ngroups);
 
-    getgrouplist(pw->pw_name, pw->pw_gid, groups, &ngroups);
+    getgrouplist(pw->pw_name, pw->pw_gid, groups.data(), &ngroups);
 
     for(int i = 0;i < ngroups;i++)
         if(groups[i] == gid)


### PR DESCRIPTION
## Jira Story
- [SC-5195](https://epcpower.atlassian.net/browse/SC-5195)

## About

This story introduces the following changes to **PMVS Editor**:
- Schemas
	- All parameters from the schema are now visible by default.
	- All schemas available in the schema cache can be selected from a list.
	- The loaded schema file name is displayed in the window title.
- Scratch Column
	- Parameter values can be edited in the Scratch column.
	- Parameter values from loaded files can be written to the Scratch column.
	- Parameter values in the Scratch column can be cleared.
	- Parameters in the Scratch column can be saved to a file (overlay file).
- PMVS Files
	- For the first loaded `pmvs` file, if the file has a hash in its metadata or the file name contains a hash, switch to the schema with the same hash if it is in the schema cache. 
	- If one or more `pmvs` files are loaded, alert the user if they are switching to a schema type that does not match the current schema type (Inverter vs System Modbus).
