### PR TITLE
fix/SC-5244 (PMVS Editor Displays Incorrect Values)

### DIFF
--- a/src/Kanoop/stringutil.cpp
+++ b/src/Kanoop/stringutil.cpp
@@ -25,7 +25,7 @@ QByteArray StringUtil::toByteArray(const QString &value)
 QString StringUtil::toString(double value, int precision, bool forcePadding)
 {
     QString result = QString("%1").arg(value, 0, 'f', precision);
-    if(forcePadding && result.contains('.') == false) {
+    if(forcePadding == false && result.contains('.')) {
         result = trimEnd(result, { '0' });
     }
 

--- a/src/Kanoop/stringutil.cpp
+++ b/src/Kanoop/stringutil.cpp
@@ -25,9 +25,11 @@ QByteArray StringUtil::toByteArray(const QString &value)
 QString StringUtil::toString(double value, int precision)
 {
     QString result = QString("%1").arg(value, 0, 'f', precision);
-    result = trimEnd(result, QList<QChar>() << '0');
-    if(result.endsWith('.')) {
-        result = trimEnd(result, QList<QChar>() << '.');
+    if(result.contains('.')) {
+        result = trimEnd(result, QList<QChar>() << '0');
+        if(result.endsWith('.')) {
+            result = trimEnd(result, QList<QChar>() << '.');
+        }
     }
     return result;
 }


### PR DESCRIPTION
## Jira Story
- [SC-5244](https://epcpower.atlassian.net/browse/SC-5244)

## About

This ticket fixes the following issues:
- Trailing zeros are removed from parameter values that are of type `float` but have `0` decimal places (original issue).
- Parameter minimum limits are not enforced (integer and double types).

This ticket also adds the following:
- The number of decimal places for parameters of type `float` are limited based on the number of decimal places defined in `toolschema`.
- Prevents the user from entering a negative sign if the parameter minimum is zero.
- Prevents the user from entering a decimal point if the parameter has no decimal places.

## Validation
- In **PMVS Editor**, open a file or use the Scratch column to edit parameter values.
- Verify the following for each parameter (integer and double) against what is defined in the `toolschema` file for that parameter:
	- Cannot enter value below minimum.
	- Cannot enter value above maximum.
	- Cannot enter values with greater decimal places.
	- Cannot enter `-` if the parameter minimum is zero.
	- Cannot enter `.` if the parameter has no decimal places.
	- Values are displayed correctly after editing.