### PR TITLE
chore(SC-5421): upgrade GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/html
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Jira Story

[SC-5421](https://epcpower.atlassian.net/browse/SC-5421) — Investigate and fix Node.js deprecation warnings in CI across all repositories

## About

Updates three GitHub Actions in `ci.yaml` from deprecated Node.js runtimes to Node.js 24-compatible versions, addressing GitHub's deprecation of Node.js 20 in Actions runners.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/upload-pages-artifact` | `@v3` | `@v4` |
| `actions/deploy-pages` | `@v4` | `@v5` |

## Validation

Confirm the CI run completes without Node.js deprecation warnings in any step log.