### PR TITLE
story(SC-5673): include moc files in source files for faster incremental builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(KANOOP_COMMON_VERSION "2.1.1")
 file(GLOB_RECURSE KANOOP_COMMON_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 file(GLOB_RECURSE KANOOP_COMMON_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
 
-qt_add_library(${PROJ} ${KANOOP_COMMON_SOURCES} ${KANOOP_COMMON_HEADERS})
+qt_add_library(${PROJ} MANUAL_FINALIZATION ${KANOOP_COMMON_SOURCES} ${KANOOP_COMMON_HEADERS})
 
 target_compile_options(${PROJ} PRIVATE -Wextra -Wall -Werror)
 
@@ -39,6 +39,17 @@ add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060000)  # Disables all t
 if (DEFINED $ENV{KYBER_OUTPUT_PREFIX})
     set(KANOOP_INSTALL_PREFIX "$ENV{KYBER_OUTPUT_PREFIX}/")
 endif()
+
+# Suppress Qt's metatype JSON generation. Nothing in this project consumes it
+# (no QML / qmltyperegistrar), and `moc --collect-json` fails on a clean build
+# for the path-prefixed manually-included moc files this library uses (split
+# include/ + src/ layout, SC-5673). Pointing INTERFACE_QT_META_TYPES_BUILD_FILE
+# at an empty file short-circuits qt6_extract_metatypes for this target and any
+# consumer that reads it. Paired with MANUAL_FINALIZATION + qt_finalize_target.
+set(_no_metatypes "${CMAKE_CURRENT_BINARY_DIR}/${PROJ}_no_metatypes.json")
+file(TOUCH "${_no_metatypes}")
+set_target_properties(${PROJ} PROPERTIES INTERFACE_QT_META_TYPES_BUILD_FILE "${_no_metatypes}")
+qt_finalize_target(${PROJ})
 
 install(TARGETS ${PROJ} LIBRARY DESTINATION "${KANOOP_INSTALL_PREFIX}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/Kanoop" DESTINATION "${KANOOP_INSTALL_PREFIX}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" FILES_MATCHING PATTERN "*.h")

--- a/src/Kanoop/clientserver/tcpserver.cpp
+++ b/src/Kanoop/clientserver/tcpserver.cpp
@@ -113,3 +113,5 @@ void TcpServer::onClientFinished()
     delete client;
 
 }
+
+#include "Kanoop/clientserver/moc_tcpserver.cpp"

--- a/src/Kanoop/clientserver/tcpserverclientobject.cpp
+++ b/src/Kanoop/clientserver/tcpserverclientobject.cpp
@@ -142,3 +142,5 @@ void TcpServerClientObject::onSslErrors(const QList<QSslError> errors)
         logText(LVL_WARNING, QString("%1 [SSL Error]: %2").arg(objectName()).arg(error.errorString()));
     }
 }
+
+#include "Kanoop/clientserver/moc_tcpserverclientobject.cpp"

--- a/src/Kanoop/clientserver/udpserver.cpp
+++ b/src/Kanoop/clientserver/udpserver.cpp
@@ -58,3 +58,5 @@ void UdpServer::serviceTransmitQueue()
         _socket->writeDatagram(datagram);
     }
 }
+
+#include "Kanoop/clientserver/moc_udpserver.cpp"

--- a/src/Kanoop/logconsumer.cpp
+++ b/src/Kanoop/logconsumer.cpp
@@ -16,3 +16,5 @@ void LogConsumer::addLogEntry(const Log::LogEntry& entry)
 {
     emit logEntry(entry);
 }
+
+#include "Kanoop/moc_logconsumer.cpp"

--- a/src/Kanoop/utility/abstractthreadclass.cpp
+++ b/src/Kanoop/utility/abstractthreadclass.cpp
@@ -232,3 +232,5 @@ void AbstractThreadClass::invokeThreadAboutToFinishAndQuit()
     _thread.quit();
 }
 
+
+#include "Kanoop/utility/moc_abstractthreadclass.cpp"

--- a/src/Kanoop/utility/appsettings.cpp
+++ b/src/Kanoop/utility/appsettings.cpp
@@ -51,3 +51,5 @@ QString AppSettings::makeCompoundObjectKey(const QString& key, const QObject* ob
     QString objectKey = makeKey(key, makeObjectKey(object));
     return objectKey;
 }
+
+#include "Kanoop/utility/moc_appsettings.cpp"


### PR DESCRIPTION
## SC-5673 — Include moc files in source files

Part of a coordinated change across all of meta-qt-mains. Each `.cpp` whose header declares `Q_OBJECT`/`Q_GADGET`/`Q_NAMESPACE` now ends with an `#include` of its generated moc file, so AUTOMOC excludes that moc from the aggregate `mocs_compilation.cpp`. Touching one Q_OBJECT header then recompiles only the TUs that include it instead of every moc in the target.

**This repo:** 6 `.cpp` file(s) converted (moc-include edits generated by `tools/check_moc_includes.py --fix` in meta-qt-mains).

**CMakeLists change (this is a library):** split include/src headers require a path-prefixed moc include, which makes Qt's metatype JSON generation (`moc --collect-json`) fail on a clean build. Nothing in this project consumes that JSON (no QML / qmltyperegistrar), so it is suppressed per target via `MANUAL_FINALIZATION` + `INTERFACE_QT_META_TYPES_BUILD_FILE` + `qt_finalize_target`. No source behavior changes.

**Measured (pulse, 64 cores, ccache disabled):** header-touch incremental rebuild 40s → 17s (−57%); clean build unchanged.

> **Merge coordination:** one of 13 PRs under SC-5673 (12 submodules + meta-qt-mains). The meta PR bumps all submodule pointers and its CI guard only passes once the pointers reference these merged commits. Submodule PRs are independent and can merge in any order; the meta PR goes last.

## Validation Steps

- [ ] Full project builds clean from scratch
  1. From a meta-qt-mains checkout with this branch's commit in the `KanoopCommonQt` submodule, wipe the build dir and configure fresh, then `cmake --build build/Desktop_Qt_6_10_1-Debug --target all --parallel`
  2. Build completes with no errors and no warnings (`-Wall -Wextra -Werror`). In particular the `moc --collect-json` / metatypes step does not fail for `KanoopCommonQt`.

- [ ] Unit tests pass
  1. Run `QT_QPA_PLATFORM=offscreen ctest --test-dir build/Desktop_Qt_6_10_1-Debug --output-on-failure`
  2. Final line reads `100% tests passed`

- [ ] moc-include guard passes
  1. From the meta-qt-mains root run `python3 tools/check_moc_includes.py KanoopCommonQt`
  2. Exits 0 with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
